### PR TITLE
fix(scrape-config): restore pod metrics

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -79,6 +79,31 @@ variable "eks_scrape_configuration" {
         target_label: __address__
         regex: (.+?)(\\:\\d+)?
         replacement: $1:10249
+    - job_name: 'kubernetes-pods'
+      honor_labels: true
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
   EOT
 }
 


### PR DESCRIPTION
## what
* add pod metrics to scrape config defaults

## why
* otherwise general metrics annotations are ignored and will be missed

## references
* [AWS OTEL config sample](https://github.com/aws-observability/aws-otel-community/blob/master/sample-configs/operator/collector-config-advanced.yaml#L194)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Prometheus metrics scraping configuration for Kubernetes pods
	- Added dynamic pod metrics discovery based on annotations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->